### PR TITLE
triggerMouseEvent now returns the triggered event

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -179,4 +179,6 @@ export async function triggerMouseEvent(chart, type, el) {
   node.dispatchEvent(event);
 
   await promise;
+
+  return event;
 }


### PR DESCRIPTION
This allows calling code to do additional tests on the event; see https://github.com/chartjs/Chart.js/pull/10046